### PR TITLE
Remove `lua` from luamodule path

### DIFF
--- a/plugin/nvim-example-lua-plugin.vim
+++ b/plugin/nvim-example-lua-plugin.vim
@@ -16,6 +16,6 @@ function LuaDoItLua()
 end
 
 print "nvim-example-lua-plugin.vim: Lua code executing."
-require("lua.luamodule.init").showstuff()
+require("luamodule.init").showstuff()
 
 EOF


### PR DESCRIPTION
Not sure if it was needed but currently it makes the plug-in crash (and the example in `:help lua` says it is appended automatically).